### PR TITLE
Fix conflict with page rewrite rule.

### DIFF
--- a/includes/class-wp-rewrite-rules.php
+++ b/includes/class-wp-rewrite-rules.php
@@ -62,6 +62,10 @@ class WP_Rewrite_Rules {
 
 		foreach ( $rules as $key => $rule ) {
 			if ( preg_match_all( '/' . self::FIELD_REGEXP . '/', $key, $key_matches ) ) {
+				if ( $this->conflicts_with_page_permalink( $key, $key_matches ) ) {
+					continue;
+				}
+
 				$key_new = preg_replace(
 					'/' . self::FIELD_REGEXP . '/',
 					'([^/]+)',
@@ -139,5 +143,23 @@ class WP_Rewrite_Rules {
 		$rule_rewrite[ WP_Request_Processor::PARAM_CUSTOMFIELD_PARAMS ][ $field_name ] = '';
 
 		return http_build_query( $rule_rewrite );
+	}
+
+	/**
+	 * Determines if rewrite rule contains only custom field tag and conflicts with pages permalink.
+	 *
+	 * @param string $key Rewrite rule.
+	 * @param array  $key_matches All found matches.
+	 *
+	 * @access private
+	 * @return boolean Whether rewrite rule conflicts with page rule.
+	 */
+	private function conflicts_with_page_permalink( $key, $key_matches ) {
+		if ( count( $key_matches[ self::FIELD_REGEXP_MAIN_GROUP ] ) == 1 ) {
+			// If the rewrite rule is only %field_some%/?$ it will be in conflict with pages rewrite rule.
+			return preg_match( '/^' . self::FIELD_REGEXP . '\/\?\$$/', $key );
+		}
+
+		return false;
 	}
 }

--- a/test/integration/suites/MetaKeyPermalinkStructure/PageWithMetaKey.php
+++ b/test/integration/suites/MetaKeyPermalinkStructure/PageWithMetaKey.php
@@ -41,7 +41,7 @@ class PageWithMetaKey extends BaseTestCase {
 	/**
 	 * Test case.
 	 */
-	function IGNORE_test_go_to_page_not_using_meta_key_permalink_structure() {
+	function test_go_to_page_not_using_meta_key_permalink_structure() {
 		// given.
 		$this->permalink_steps->given_permalink_structure( '/%field_some_meta_key%/%postname%/' );
 

--- a/test/integration/suites/PermalinkWithAttributesStructure/PostWithMetaKey.php
+++ b/test/integration/suites/PermalinkWithAttributesStructure/PostWithMetaKey.php
@@ -72,7 +72,8 @@ class PostWithMetaKey extends BaseTestCase {
 		$this->permalink_asserter->has_permalink( $created_post_id, '/some-meta-value/some-post-title/' );
 
 		$this->assertThatHookWasCalledWith(
-			'some_meta_key', 'Some meta value',
+			'some_meta_key',
+			'Some meta value',
 			array( 'some_attribute' => true ),
 			$created_post_id
 		);
@@ -103,7 +104,8 @@ class PostWithMetaKey extends BaseTestCase {
 		$this->navigation_asserter->then_displayed_post( $created_post_id );
 
 		$this->assertThatHookWasCalledWith(
-			'some_meta_key', 'Some meta value',
+			'some_meta_key',
+			'Some meta value',
 			array( 'some_attribute' => true ),
 			$created_post_id
 		);
@@ -134,7 +136,8 @@ class PostWithMetaKey extends BaseTestCase {
 		$this->navigation_asserter->then_displayed_post( $created_post_id );
 
 		$this->assertThatHookWasCalledWith(
-			'some_meta_key', 'Some meta value',
+			'some_meta_key',
+			'Some meta value',
 			array(
 				'some_attribute'        => true,
 				'some_second_attribute' => 'some value',


### PR DESCRIPTION
Fix of the https://github.com/athlan/wordpress-custom-fields-permalink-plugin/issues/17 issue.

The initial problem is that extra `'%field_custom1%/?$' => 'index.php?%field_custom1%$matches[1]',` rule is added because of detection of tag in wordpress:
* [Reference 1](https://github.com/WordPress/WordPress/blob/2e8c823212d7c5b87e607cab6b53d070358ff3ee/wp-includes/class-wp-rewrite.php#L896-L898)
* [Reference 2](https://github.com/WordPress/WordPress/blob/2e8c823212d7c5b87e607cab6b53d070358ff3ee/wp-includes/class-wp-rewrite.php#L1037-L1165)

⚠️ This fix will disable the possibility to determine post directly by custom meta value (like permalink structure `%field_custom1%` only without `%postname%`).

However it is not aim of this plugin to clearly determine post by custom post meta value because it have to resolve slugs conflicts (like adding suffix to post lug build-in wordpress). Some users might rely on thi feature.