### PR TITLE
Fix private posts check for non-permitted user

### DIFF
--- a/includes/class-wp-request-processor.php
+++ b/includes/class-wp-request-processor.php
@@ -87,6 +87,9 @@ class WP_Request_Processor {
 		}
 
 		$post = $wp_query->post;
+		if ( null === $post ) {
+			return false;
+		}
 
 		// Analyse only if custom field used in query.
 		if ( ! array_key_exists( self::PARAM_CUSTOMFIELD_PARAMS, $wp_query->query_vars )

--- a/test/integration/bootstrap.php
+++ b/test/integration/bootstrap.php
@@ -33,6 +33,7 @@ require $_tests_dir . '/includes/bootstrap.php';
 require 'class-basetestcase.php';
 require 'class-permalinksteps.php';
 require 'class-customposttypesteps.php';
+require 'class-authsteps.php';
 require 'class-permalinkasserter.php';
 require 'class-navigationasserter.php';
 

--- a/test/integration/class-authsteps.php
+++ b/test/integration/class-authsteps.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Tests util file.
+ *
+ * @package WordPress_Custom_Fields_Permalink
+ */
+
+/**
+ * Class AuthSteps contains utility methods for authentication.
+ */
+class AuthSteps {
+
+	/**
+	 * AuthSteps constructor.
+	 */
+	public function __construct() {
+	}
+
+	/**
+	 * Logged as given user and password.
+	 *
+	 * @param string $username User name.
+	 * @param string $password User password.
+	 * @throws Exception When authentication fails.
+	 */
+	public function given_logged_as( $username, $password ) {
+		$result = wp_signon(
+			array(
+				'user_login'    => $username,
+				'user_password' => $password,
+			)
+		);
+
+		if ( ! ( $result instanceof WP_User ) ) {
+			throw new Exception( "Couldn't login user" );
+		}
+
+		wp_set_current_user( $result->ID, $result->user_login );
+	}
+
+	/**
+	 * Logged as admin.
+	 */
+	public function given_logged_as_admin() {
+		$this->given_logged_as( 'admin', 'password' );
+	}
+}

--- a/test/integration/class-authsteps.php
+++ b/test/integration/class-authsteps.php
@@ -20,16 +20,10 @@ class AuthSteps {
 	 * Logged as given user and password.
 	 *
 	 * @param string $username User name.
-	 * @param string $password User password.
 	 * @throws Exception When authentication fails.
 	 */
-	public function given_logged_as( $username, $password ) {
-		$result = wp_signon(
-			array(
-				'user_login'    => $username,
-				'user_password' => $password,
-			)
-		);
+	public function given_logged_as( $username ) {
+		$result = get_user_by( 'login', $username );
 
 		if ( ! ( $result instanceof WP_User ) ) {
 			throw new Exception( "Couldn't login user" );

--- a/test/integration/class-basetestcase.php
+++ b/test/integration/class-basetestcase.php
@@ -25,6 +25,13 @@ class BaseTestCase extends WP_UnitTestCase {
 	protected $custom_post_type_steps;
 
 	/**
+	 * The AuthSteps.
+	 *
+	 * @var AuthSteps
+	 */
+	protected $auth_steps;
+
+	/**
 	 * The PermalinkAsserter.
 	 *
 	 * @var PermalinkAsserter
@@ -46,6 +53,7 @@ class BaseTestCase extends WP_UnitTestCase {
 
 		$this->permalink_steps        = new PermalinkSteps( $this );
 		$this->custom_post_type_steps = new CustomPostTypeSteps( $this );
+		$this->auth_steps             = new AuthSteps( $this );
 		$this->permalink_asserter     = new PermalinkAsserter( $this );
 		$this->navigation_asserter    = new NavigationAsserter( $this );
 	}

--- a/test/integration/suites/MetaKeyPermalinkStructure/PrivatePostWithMetaKey.php
+++ b/test/integration/suites/MetaKeyPermalinkStructure/PrivatePostWithMetaKey.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Tests case.
+ *
+ * @package WordPress_Custom_Fields_Permalink
+ */
+
+namespace CustomFieldsPermalink\Tests\Integration\MetaKeyPermalinkStructure;
+
+use BaseTestCase;
+
+/**
+ * Class PrivatePostWithMetaKey
+ */
+class PrivatePostWithMetaKey extends BaseTestCase {
+
+	/**
+	 * Test case.
+	 */
+	function test_generates_permalink_to_private_post() {
+		// given.
+		$this->permalink_steps->given_permalink_structure( '/%field_some_meta_key%/%postname%/' );
+
+		$post_params     = array(
+			'post_title'  => 'Some post title',
+			'post_status' => 'private',
+			'meta_input'  => array(
+				'some_meta_key'       => 'Some meta value',
+				'some_other_meta_key' => 'Some other meta value',
+			),
+		);
+		$created_post_id = $this->factory()->post->create( $post_params );
+
+		// when & then.
+		$this->permalink_asserter->has_permalink( $created_post_id, '/some-meta-value/some-post-title/' );
+	}
+
+	/**
+	 * Test case.
+	 */
+	function test_go_to_private_post_using_meta_key_permalink_structure() {
+		// given.
+		$this->permalink_steps->given_permalink_structure( '/%field_some_meta_key%/%postname%/' );
+
+		$post_params     = array(
+			'post_title'  => 'Some post title',
+			'post_status' => 'private',
+			'meta_input'  => array(
+				'some_meta_key'       => 'Some meta value',
+				'some_other_meta_key' => 'Some other meta value',
+			),
+		);
+		$created_post_id = $this->factory()->post->create( $post_params );
+
+		// when.
+		$this->go_to( '/some-meta-value/some-post-title/' );
+
+		// then.
+		$this->navigation_asserter->then_not_displayed_post( $created_post_id )
+			->and_also()
+			->then_is_404();
+	}
+}

--- a/test/integration/suites/MetaKeyPermalinkStructure/PrivatePostWithMetaKey.php
+++ b/test/integration/suites/MetaKeyPermalinkStructure/PrivatePostWithMetaKey.php
@@ -38,7 +38,7 @@ class PrivatePostWithMetaKey extends BaseTestCase {
 	/**
 	 * Test case.
 	 */
-	function test_go_to_private_post_using_meta_key_permalink_structure() {
+	function test_not_go_to_private_post_using_meta_key_permalink_structure_as_anonymous_user() {
 		// given.
 		$this->permalink_steps->given_permalink_structure( '/%field_some_meta_key%/%postname%/' );
 
@@ -59,5 +59,32 @@ class PrivatePostWithMetaKey extends BaseTestCase {
 		$this->navigation_asserter->then_not_displayed_post( $created_post_id )
 			->and_also()
 			->then_is_404();
+	}
+
+	/**
+	 * Test case.
+	 */
+	function test_go_to_private_post_using_meta_key_permalink_structure_as_admin_user() {
+		// given.
+		$this->auth_steps->given_logged_as_admin();
+		$this->permalink_steps->given_permalink_structure( '/%field_some_meta_key%/%postname%/' );
+
+		$post_params     = array(
+			'post_title'  => 'Some post title',
+			'post_status' => 'private',
+			'meta_input'  => array(
+				'some_meta_key'       => 'Some meta value',
+				'some_other_meta_key' => 'Some other meta value',
+			),
+		);
+		$created_post_id = $this->factory()->post->create( $post_params );
+		var_dump( is_user_logged_in() );
+		var_dump( wp_get_current_user() );
+
+		// when.
+		$this->go_to( '/some-meta-value/some-post-title/' );
+
+		// then.
+		$this->navigation_asserter->then_displayed_post( $created_post_id );
 	}
 }

--- a/test/integration/suites/MetaKeyPermalinkStructure/PrivatePostWithMetaKey.php
+++ b/test/integration/suites/MetaKeyPermalinkStructure/PrivatePostWithMetaKey.php
@@ -78,8 +78,6 @@ class PrivatePostWithMetaKey extends BaseTestCase {
 			),
 		);
 		$created_post_id = $this->factory()->post->create( $post_params );
-		var_dump( is_user_logged_in() );
-		var_dump( wp_get_current_user() );
 
 		// when.
 		$this->go_to( '/some-meta-value/some-post-title/' );

--- a/test/integration/suites/PermalinkWithAttributesStructure/PostWithMetaKey.php
+++ b/test/integration/suites/PermalinkWithAttributesStructure/PostWithMetaKey.php
@@ -72,7 +72,8 @@ class PostWithMetaKey extends BaseTestCase {
 		$this->permalink_asserter->has_permalink( $created_post_id, '/some-meta-value/some-post-title/' );
 
 		$this->assertThatHookWasCalledWith(
-			'some_meta_key', 'Some meta value',
+			'some_meta_key',
+			'Some meta value',
 			array( 'some_attribute' => true ),
 			$created_post_id
 		);
@@ -103,7 +104,8 @@ class PostWithMetaKey extends BaseTestCase {
 		$this->navigation_asserter->then_displayed_post( $created_post_id );
 
 		$this->assertThatHookWasCalledWith(
-			'some_meta_key', 'Some meta value',
+			'some_meta_key',
+			'Some meta value',
 			array( 'some_attribute' => true ),
 			$created_post_id
 		);
@@ -134,7 +136,8 @@ class PostWithMetaKey extends BaseTestCase {
 		$this->navigation_asserter->then_displayed_post( $created_post_id );
 
 		$this->assertThatHookWasCalledWith(
-			'some_meta_key', 'Some meta value',
+			'some_meta_key',
+			'Some meta value',
 			array(
 				'some_attribute'        => true,
 				'some_second_attribute' => 'some value',


### PR DESCRIPTION
This is a fix for issue https://github.com/athlan/wordpress-custom-fields-permalink-plugin/issues/38

Scenario:
* **Given** we have a private post
* **And** we visit the link for provate post as non-authenticated user (no permissions)
* **Then** the following error occurs:
```
Warning: Invalid argument supplied for foreach() in /var/www/html/web/wp/wp-content/plugins/custom-fields-permalink-redux/includes/class-wp-post-meta.php on line 38

Warning: array_key_exists() expects parameter 2 to be array, boolean given in /var/www/html/web/wp/wp-content/plugins/custom-fields-permalink-redux/includes/class-wp-post-meta.php on line 59
```